### PR TITLE
Fix multiple typos

### DIFF
--- a/pandas/guide/contents.html
+++ b/pandas/guide/contents.html
@@ -52,7 +52,7 @@ the actual method parameters. And while docstrings use the numpy docstring
 convention, they could benefit from some pandas specific convention.</p>
 <p>There are around 1,000 API pages in pandas, meaning that the effort to fix,
 standardize and improve all the API documentation is huge. But the pandas
-user base is also huge. And Pythonistas are very active an well organized.
+user base is also huge. And Pythonistas are very active and well organized.
 So, we will work together from all around the world to take care of every
 single API, in a single day.</p>
 <p>This document provides all the necessary information to participate to the

--- a/pandas/guide/organizers.html
+++ b/pandas/guide/organizers.html
@@ -55,7 +55,7 @@ may already have some companies who hosted events before, and are happy to do
 it again. If that is not the case, they can mail the members of the community,
 and surely one of them works in a company happy to offer the venue.</p>
 <p>If that does not work for you, universities, local government agencies
-supporting employment and enterpreneurship, startup incubators, and
+supporting employment and entrepreneurship, startup incubators, and
 co-working spaces, could be interested in offering you a venue. In general,
 it is easier to get a positive answer by trying to directly contact someone
 there, than by filling a form or sending an email to <a class="reference external" href="mailto:info&#37;&#52;&#48;whatever">info<span>&#64;</span>whatever</a>.</p>
@@ -68,7 +68,7 @@ contact the companies asking if they could be interested in hosting the event.
 Python programmers and data scientists are hard to find, and it can be a great
 opportunity for them, to get their company promoted.</p>
 <p>If nothing else works, you can find a bar, pub, restaurant… with some quiet
-area for the spint. And if you do not even find that, please contact us, and
+area for the sprint. And if you do not even find that, please contact us, and
 we will find a solution.</p>
 </div>
 <div class="section" id="the-local-community-and-publishing-the-event">
@@ -147,7 +147,7 @@ learning it, as in the sprint is basically what you need to do. :)</p>
 <li>Inside your local copy of the repo (<cite>cd python-sprints.github.io</cite>)…</li>
 <li>Create a branch for your changes: <cite>git checkout -b adding_&lt;your-city&gt;_chapter</cite></li>
 <li>Edit the file with the chapter info: <cite>vim pandas/index.html</cite> and add an entry with the same fields as the rest</li>
-<li>Add your changed to be commited: <cite>git add pandas/index.html</cite></li>
+<li>Add your changed to be committed: <cite>git add pandas/index.html</cite></li>
 <li>Commit your changes: <cite>git commit -m “Adding &lt;your-city&gt; to the pandas sprint page”</cite></li>
 <li>Push your changes to your fork: <cite>git push -u origin adding_&lt;your-city&gt;_chapter</cite></li>
 <li>Create a pull request by clicking on the “Compare &amp; pull request” button in the yellow box at <a class="reference external" href="https://github.com/python-sprints/python-sprints.github.io">https://github.com/python-sprints/python-sprints.github.io</a></li>
@@ -203,7 +203,7 @@ times.</p>
 <p>One important thing to consider, is that <strong>quality is much more important
 than quantity</strong>. For pandas, it will be much more productive if we send
 50 excellent pull requests, than if we send 500 not so good pull requests.</p>
-<p>Core developers are usually the bottle neck of open source projects. And
+<p>Core developers are usually the bottleneck of open source projects. And
 while with their experience they will surely provide great reviews to
 enrich our contributions, we surely do not want to waste their time by reviewing
 code that doesn’t work, spelling mistakes, bad grammar, incorrect text, or

--- a/pandas/guide/pandas_docstring.html
+++ b/pandas/guide/pandas_docstring.html
@@ -47,7 +47,7 @@
 <p>A Python docstring is a string used to document a Python function or method,
 so programmers can understand what it does without having to read the details
 of the implementation.</p>
-<p>Also, it is a commonn practice to generate online (html) documentation
+<p>Also, it is a common practice to generate online (html) documentation
 automatically from docstrings. <a class="reference external" href="http://www.sphinx-doc.org">Sphinx</a> serves
 this purpose.</p>
 <p>Next example gives an idea on how a docstring looks like:</p>
@@ -369,7 +369,7 @@ one value (a tuple of values).</p>
 <div class="highlight-python"><div class="highlight"><pre><span></span><span class="k">def</span> <span class="nf">sample</span><span class="p">():</span>
     <span class="sd">&quot;&quot;&quot;Generate and return a random number.</span>
 
-<span class="sd">    The value is sampled from a continuos uniform distribution between</span>
+<span class="sd">    The value is sampled from a continuous uniform distribution between</span>
 <span class="sd">    0 and 1.</span>
 
 <span class="sd">    Returns</span>
@@ -404,7 +404,7 @@ one value (a tuple of values).</p>
 <div class="highlight-python"><div class="highlight"><pre><span></span><span class="k">def</span> <span class="nf">sample_values</span><span class="p">():</span>
     <span class="sd">&quot;&quot;&quot;Generate an infinite sequence of random numbers.</span>
 
-<span class="sd">    The values are sampled from a continuos uniform distribution between</span>
+<span class="sd">    The values are sampled from a continuous uniform distribution between</span>
 <span class="sd">    0 and 1.</span>
 
 <span class="sd">    Yields</span>
@@ -459,7 +459,7 @@ the one referencing. The description must also finish with a dot.</p>
 <p>Note that in “Returns” and “Yields”, the description is located in the
 following line than the type. But in this section it is located in the same
 line, with a colon in between. If the description does not fit in the same
-line, it can continue in the next ones, but it has to be indenteted in them.</p>
+line, it can continue in the next ones, but it has to be indented in them.</p>
 <p>For example:</p>
 <div class="highlight-python"><div class="highlight"><pre><span></span><span class="k">class</span> <span class="nc">Series</span><span class="p">:</span>
     <span class="k">def</span> <span class="nf">head</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>

--- a/pandas/guide/pandas_setup.html
+++ b/pandas/guide/pandas_setup.html
@@ -49,7 +49,7 @@
 <li>An editor (vim, emacs, PyCharm,…). Make sure the editor is set up to use 4 spaces for tabs.</li>
 </ul>
 <p>The <a class="reference external" href="https://pandas.pydata.org/pandas-docs/stable/contributing.html">pandas contributing guide</a>
-contains detailed instructions on how to set up a pandas devlopment environemnt.
+contains detailed instructions on how to set up a pandas development environment.
 This document is a short summary with some additional information specific to
 the sprint.</p>
 <div class="admonition note">

--- a/pandas/index.html
+++ b/pandas/index.html
@@ -281,7 +281,15 @@
              "address": "TBC",
              "lat": 19.432626,
              "lng": -99.133203},
-
+            {"title": "Buenos Aires, Argentina",
+             "description": "Buenos Aires",
+             "url": "https://www.meetup.com/es-ES/DigitalAnalyticsBA/events/248300335/",
+             "sponsor_image": "",
+             "sponsor_url": "",
+             "time": "10:00am",
+             "address": "Monroe 860, Belgrano, CABA",
+             "lat":-34.5489267,
+             "lng":-58.4437257},
 
             // Africa
             {"title": "Lagos",


### PR DESCRIPTION
Fixed typos in: - pandas/guide/pandas_setup.html
                        - pandas/guide/contents.html
                        - pandas/guide/organizers.html
                        - pandas/guide/pandas_docstring.html
 