### PR TITLE
Fixed broken link syntax

### DIFF
--- a/pandas/guide/source/pandas_setup.rst
+++ b/pandas/guide/source/pandas_setup.rst
@@ -64,7 +64,7 @@ repository:
 3. Set up a Python environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Download and install `Anaconda <https://www.anaconda.com/download/>`
+* Download and install `Anaconda <https://www.anaconda.com/download/>`_.
 
 .. note::
     **Windows users**: run the next commands in the Anaconda Prompt (found in the Anaconda

--- a/pandas/guide/source/pandas_setup.rst
+++ b/pandas/guide/source/pandas_setup.rst
@@ -74,7 +74,11 @@ repository:
     * If you chose to prepend Anaconda to your PATH during install adding it to your ``~/.bashrc``, just restart your terminal.
     * Otherwise, run ``export PATH="<path-to-anaconda>/bin:$PATH"`` in your terminal. Keep in mind that it will be active exclusively in the terminal you run this command.
 * Create a conda environment:
-    ``conda env create -n pandas_dev -f <path-to-pandas>/ci/environment-dev.yaml``
+    ``conda env create -n pandas_dev -f <path-to-pandas-dir>/ci/environment-dev.yaml``
+
+.. note::
+    **Windows users**: If you're copy-pasting the path, replace all pasted ``\`` characters with ``/`` for the command to work.
+
 * Activate the new conda environment:
     ``conda activate pandas_dev``    
 * Install pandas development dependencies:

--- a/pandas/guide/source/pandas_setup.rst
+++ b/pandas/guide/source/pandas_setup.rst
@@ -76,7 +76,7 @@ repository:
 * Create a conda environment:
     ``conda env create -n pandas_dev -f <path-to-pandas>/ci/environment-dev.yaml``
 * Activate the new conda environment:
-    ``source activate pandas_dev``    
+    ``conda activate pandas_dev``    
 * Install pandas development dependencies:
     ``conda install -c defaults -c conda-forge --file=<pandas-dir>/ci/requirements-optional-conda.txt``
 

--- a/pandas/guide/source/pandas_setup.rst
+++ b/pandas/guide/source/pandas_setup.rst
@@ -82,7 +82,7 @@ repository:
 * Activate the new conda environment:
     ``conda activate pandas_dev``    
 * Install pandas development dependencies:
-    ``conda install -c defaults -c conda-forge --file=<pandas-dir>/ci/requirements-optional-conda.txt``
+    ``conda install -c defaults -c conda-forge --file=<path-to-pandas-dir>/ci/requirements-optional-conda.txt``
 
 4. Compile C code in pandas
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
* Fixed broken anaconda download URL.
* Fixed one of the Anaconda setup commands because it wasn't working.
* Added note about pasting paths on Windows in the Anaconda prompt.