### PR TITLE
Correct dev env creation command

### DIFF
--- a/pandas/guide/source/pandas_setup.rst
+++ b/pandas/guide/source/pandas_setup.rst
@@ -112,7 +112,7 @@ To fetch the latest updates from the pandas repository, follow the steps in
 
 * Activate the new conda environment: ::
 
-    source activate pandas_dev
+    source activate pandas-dev
 
 
 4. Compile C code in pandas

--- a/pandas/guide/source/pandas_setup.rst
+++ b/pandas/guide/source/pandas_setup.rst
@@ -104,7 +104,7 @@ To fetch the latest updates from the pandas repository, follow the steps in
 
 * Create a conda environment: ::
 
-    conda env create -n pandas_dev -f <path-to-pandas-dir>/environment.yaml
+    conda env create
 
   .. note::
     **Windows users**: If you're copy-pasting the path, replace all pasted

--- a/pandas/guide/source/pandas_setup.rst
+++ b/pandas/guide/source/pandas_setup.rst
@@ -106,10 +106,6 @@ To fetch the latest updates from the pandas repository, follow the steps in
 
     conda env create
 
-  .. note::
-    **Windows users**: If you're copy-pasting the path, replace all pasted
-    ``\`` characters with ``/`` for the command to work.
-
 * Activate the new conda environment: ::
 
     source activate pandas-dev

--- a/pandas/guide/source/pandas_setup.rst
+++ b/pandas/guide/source/pandas_setup.rst
@@ -114,9 +114,6 @@ To fetch the latest updates from the pandas repository, follow the steps in
 
     source activate pandas_dev
 
-* Install pandas development dependencies: ::
-
-    conda install -c defaults -c conda-forge --file=<path-to-pandas-dir>/ci/requirements-optional-conda.txt
 
 4. Compile C code in pandas
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pandas/guide/source/pandas_setup.rst
+++ b/pandas/guide/source/pandas_setup.rst
@@ -104,7 +104,7 @@ To fetch the latest updates from the pandas repository, follow the steps in
 
 * Create a conda environment: ::
 
-    conda env create -n pandas_dev -f <path-to-pandas-dir>/ci/environment-dev.yaml
+    conda env create -n pandas_dev -f <path-to-pandas-dir>/environment.yaml
 
   .. note::
     **Windows users**: If you're copy-pasting the path, replace all pasted


### PR DESCRIPTION
`<path-to-pandas-dir>/ci/environment-dev.yaml` no longer exists and `<path-to-pandas-dir>/environment.yaml` appears to include all of the dev packages, so we used the edited version in this PR to set up dev envs at the PyCon Canada 2018 sprints.